### PR TITLE
Convert README to rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,13 +1,12 @@
-# Indent
+= Indent
+{<img src="https://travis-ci.org/drusepth/Indent.png?branch=master" alt="Build Status" />}[https://travis-ci.org/drusepth/Indent]
 
-[![Build Status](https://travis-ci.org/drusepth/Indent.png)](https://travis-ci.org/drusepth/Indent)
+== What is Indent?
+see {live website}[http://indentapp.com]
 
-## What is Indent?
-see [live website](http://indentapp.com)
+Indent is a set of tools for writers, game designers, and roleplayers to create magnificent universes – and everything within them.
 
-> Indent is a set of tools for writers, game designers, and roleplayers to create magnificent universes – and everything within them.
-
-> From a simple interface in your browser, on your phone, or on your tablet, you can do everything you'd ever want to do while creating your own little (or big!) world.
+From a simple interface in your browser, on your phone, or on your tablet, you can do everything you'd ever want to do while creating your own little (or big!) world.
 
 Indent is a writer's planning tool for creating anything from universes to characters, to plots, to individual items.
 
@@ -15,14 +14,13 @@ It is also meant to expand into many areas to benefit writers (and exciting to d
 
 - Automated revision services
 - Structuring real-time natural language processing output into a semantically reusable state
-- Decision-making algorithms for improving reading comprehension, reading level, accent-correction, and other real-
- time writing suggestions
+- Decision-making algorithms for improving reading comprehension, reading level, accent-correction, and other real-time writing suggestions
 - A knowledge graph of structured data in your universe, and an engine to manipulate it in awesome ways
 - Machine learning on generating character and location names, suggesting realistic defaults (random or not), and more
 - and tons more
 
 
-## The Issue Tracker
+== The Issue Tracker
 
 If you are interested in helping out, check out the issue tracker. I've loaded it with tons of action-based, chunk-sized improvements that I think anyone familiar with Rails will be able to jump in and complete. Feel free to make suggestions, open issues, join discussions, or ask where you should look in the code to get started implementing something. :)
 
@@ -31,7 +29,7 @@ You'll notice there are *a lot* of issues in *a lot* of milestones. Call it feat
 TL;DR Milestones are independent of each other -- work on whatever you want to see made!
 
 
-## Installing the Indent stack locally
+== Installing the Indent stack locally
 
 Install curl
 
@@ -87,7 +85,7 @@ Finally, run the server with
 
     rails server
 
-## Deployment to indentapp.com
+== Deployment to indentapp.com
 
 Deployment to the live stage will only be done by approved developers, and consists of a deployment of
 
@@ -100,6 +98,8 @@ Deployment to the live stage will only be done by approved developers, and consi
 - deploy from staging to live (viewed at indentapp.com)
 
 
-## Thanks
+== Thanks
 
 Feel free to get in touch if you have any questions, comments, or concerns! :)
+
+(c) Andrew Brown 2014


### PR DESCRIPTION
Just a suggestion! Might as well, since the code documentation will be rdoc anyway, and GitHub now supports it as a README like it does with Markdown.

The only changes I made were for rdoc formatting, I didn't change any content.
